### PR TITLE
Sync of non-existing fields; refactor comapre mechanism

### DIFF
--- a/tine20/Tinebase/User.php
+++ b/tine20/Tinebase/User.php
@@ -670,7 +670,7 @@ class Tinebase_User implements Tinebase_Controller_Interface
      * @throws Tinebase_Exception_InvalidArgument
      * @throws Tinebase_Exception_Record_Validation
      */
-    protected static function _checkAndUpdateCurrentUser(Tinebase_Model_FullUser $currentUser, Tinebase_Model_FullUser $user, array $options)
+    protected static function _checkAndUpdateCurrentUser(Tinebase_Model_FullUser $currentUser, Tinebase_Model_FullUser $user, array $options = [])
     {
        $fieldsToSync = [
             // true = REQUIRED, may be empty; false = OPTIONAL, omit if empty/missing; null IGNORE always
@@ -687,8 +687,8 @@ class Tinebase_User implements Tinebase_Controller_Interface
             'accountLoginShell' => false, 
             'visibility' => false, 
             'accountStatus' => function($options) {
-                if (isset($options['syncAccountStatus']) && $options['syncAccountStatus']) {
-                    return true;
+                if (isset($options['syncAccountStatus'])) {
+                    return (bool) $options['syncAccountStatus'];
                 }
                 return null; 
             }, 
@@ -718,7 +718,7 @@ class Tinebase_User implements Tinebase_Controller_Interface
                 if (Tinebase_Core::isLogLevel(Zend_Log::DEBUG)) Tinebase_Core::getLogger()->debug(__METHOD__ . '::' . __LINE__
                     . ' Diff found in field ' . $field  . ' current: ' . $currentUser->{$field} . ' new: ' . $user->{$field});
                 $currentUser->{$field} = $user->{$field};
-                $recordNeedsUpdate = true;                
+                $recordNeedsUpdate = true;
             }
         }
 

--- a/tine20/Tinebase/User.php
+++ b/tine20/Tinebase/User.php
@@ -672,30 +672,53 @@ class Tinebase_User implements Tinebase_Controller_Interface
      */
     protected static function _checkAndUpdateCurrentUser(Tinebase_Model_FullUser $currentUser, Tinebase_Model_FullUser $user, array $options)
     {
-        $fieldsToSync = ['accountLoginName', 'accountLastPasswordChange', 'accountExpires', 'accountPrimaryGroup',
-            'accountDisplayName', 'accountLastName', 'accountFirstName', 'accountFullName', 'accountEmailAddress',
-            'accountHomeDirectory', 'accountLoginShell', 'visibility'];
-        $nonEmptyFields = ['visibility'];
-        if (isset($options['syncAccountStatus']) && $options['syncAccountStatus']) {
-            $fieldsToSync[] = 'accountStatus';
-        }
+       $fieldsToSync = [
+            // true = REQUIRED, may be empty; false = OPTIONAL, omit if empty/missing; null IGNORE always
+            'accountLoginName' => true, 
+            'accountLastPasswordChange' => false, 
+            'accountExpires' => false, 
+            'accountPrimaryGroup' => true,
+            'accountDisplayName' => false, 
+            'accountLastName' => true, 
+            'accountFirstName' => true, 
+            'accountFullName' => false, 
+            'accountEmailAddress' => true,
+            'accountHomeDirectory' => false, 
+            'accountLoginShell' => false, 
+            'visibility' => false, 
+            'accountStatus' => function($options) {
+                if (isset($options['syncAccountStatus']) && $options['syncAccountStatus']) {
+                    return true;
+                }
+                return null; 
+            }, 
+        ];
 
         if (Tinebase_Core::isLogLevel(Zend_Log::DEBUG)) Tinebase_Core::getLogger()->debug(__METHOD__ . '::' . __LINE__
-            . ' Fields to sync: ' . print_r($fieldsToSync, true));
+            . ' Fields to sync (bool: sync empty?): ' . print_r($fieldsToSync, true));
 
         $recordNeedsUpdate = false;
-        foreach ($fieldsToSync as $field) {
-            if ($currentUser->{$field} !== $user->{$field} && (! empty($user->{$field}) || ! in_array($field, $nonEmptyFields))) {
-                // ldap might not have time information on datetime fields, so we ignore these, if the date matches
-                if ($user->{$field} instanceof Tinebase_DateTime && $currentUser->{$field} instanceof Tinebase_DateTime
+        foreach ($fieldsToSync as $field => $syncRequired) {
+            // IGNORE field even if not empty
+            if ($syncRequired === null) {
+                continue;
+            }
+            // Ignore OPTIONAL fields if empty or missing
+            else if (($syncRequired === false) && empty($user->{$field})) {
+                continue;
+            }
+            // ldap might not have time information on datetime fields, so we ignore these, if the date matches
+            else if ($user->{$field} instanceof Tinebase_DateTime && $currentUser->{$field} instanceof Tinebase_DateTime
                     && $user->{$field}->hasSameDate($currentUser->{$field})
-                ) {
-                    continue;
-                }
+            ) {
+                continue;
+            }
+            // SYNC NON-EMPTY OPTIONAL or REQUIRED fields
+            else if ($currentUser->{$field} !== $user->{$field}) {
                 if (Tinebase_Core::isLogLevel(Zend_Log::DEBUG)) Tinebase_Core::getLogger()->debug(__METHOD__ . '::' . __LINE__
                     . ' Diff found in field ' . $field  . ' current: ' . $currentUser->{$field} . ' new: ' . $user->{$field});
                 $currentUser->{$field} = $user->{$field};
-                $recordNeedsUpdate = true;
+                $recordNeedsUpdate = true;                
             }
         }
 


### PR DESCRIPTION
For some non-existing fields in LDAP it is preferable to keep the values Tinebase_User already originally has instead of mark them as empty. This affects i.e.  *accountLastPasswordChange* if users change their passwords only in Tine 2.0 to avoid unnecessary Timemachine_Modlog issue (fix [#7398](https://github.com/tine20/tine20/issues/7398)). 

Also current implementation is contra-intuitive, $nonEmptyFields holds fields that are to be synced only if changed (thus existing). The commit improves readability of compare mechanism - "continue early".

ToDo: Mechanism to undo the unnecessary Timemachine_Modlog which can sum up to a lot of DB entries over time. 